### PR TITLE
Feat/foodlist page

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,6 @@ To run tests, run the following command:
 <!-- FUTURE FEATURES -->
 
 ## 🔭 Future Features <a name="future-features"></a>
-
-- [ ] **Login and registration pages**
-- [ ] **Food list page**
 - [ ] **Recipes list page**
 - [ ] **Public recipe list page**
 - [ ] **Recipe details page**

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -1,0 +1,39 @@
+class FoodsController < ApplicationController
+	before_action :authenticate_user!
+	before_action :set_food, only: [:show, :destroy]
+	# load_and_authorize_resource except: [:show]
+
+	def index
+		@foods = current_user.foods
+	end
+
+	def new
+		@food = Food.new
+	end
+
+	def create
+		@food = current_user.foods.build(food_params)
+		if @food.save
+			redirect_to foods_path, notice: 'Food item added successfully.'
+		else
+			render :new
+		end
+	end
+
+	def show
+		if @food.destroy
+			redirect_to foods_path, notice: 'Food item deleted.'
+		else
+			redirect_to foods_path, alert: 'Failed to delete food item.'
+		end
+  end
+
+	def set_food
+		@food = current_user.foods.find(params[:id])
+	end
+
+	def food_params
+		params.require(:food).permit(:name, :quantity, :price)
+	end
+
+end

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -1,39 +1,38 @@
 class FoodsController < ApplicationController
-	before_action :authenticate_user!
-	before_action :set_food, only: [:show, :destroy]
-	# load_and_authorize_resource except: [:show]
+  before_action :authenticate_user!
+  before_action :set_food, only: %i[show destroy]
+  # load_and_authorize_resource except: [:show]
 
-	def index
-		@foods = current_user.foods
-	end
-
-	def new
-		@food = Food.new
-	end
-
-	def create
-		@food = current_user.foods.build(food_params)
-		if @food.save
-			redirect_to foods_path, notice: 'Food item added successfully.'
-		else
-			render :new
-		end
-	end
-
-	def show
-		if @food.destroy
-			redirect_to foods_path, notice: 'Food item deleted.'
-		else
-			redirect_to foods_path, alert: 'Failed to delete food item.'
-		end
+  def index
+    @foods = current_user.foods
   end
 
-	def set_food
-		@food = current_user.foods.find(params[:id])
-	end
+  def new
+    @food = Food.new
+  end
 
-	def food_params
-		params.require(:food).permit(:name, :quantity, :price)
-	end
+  def create
+    @food = current_user.foods.build(food_params)
+    if @food.save
+      redirect_to foods_path, notice: 'Food item added successfully.'
+    else
+      render :new
+    end
+  end
 
+  def show
+    if @food.destroy
+      redirect_to foods_path, notice: 'Food item deleted.'
+    else
+      redirect_to foods_path, alert: 'Failed to delete food item.'
+    end
+  end
+
+  def set_food
+    @food = current_user.foods.find(params[:id])
+  end
+
+  def food_params
+    params.require(:food).permit(:name, :quantity, :price)
+  end
 end

--- a/app/helpers/foods_helper.rb
+++ b/app/helpers/foods_helper.rb
@@ -1,0 +1,2 @@
+module FoodsHelper
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,6 +5,8 @@ class Ability
     user ||= User.new
 
     can :destroy, Recipe, user_id: user.id
+
+    can :destroy, Food, user_id: user.id
     # Define abilities for the passed in user here. For example:
     #
     #   user ||= User.new # guest user (not logged in)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :foods
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/foods/index.html.erb
+++ b/app/views/foods/index.html.erb
@@ -1,0 +1,19 @@
+<h1>Your Food List</h1>
+<table>
+  <tr>
+    <th>Name</th>
+    <th>Quantity</th>
+    <th>Unit Price</th>
+    <th>Action</th>
+  </tr>
+  <% @foods.each do |food| %>
+    <tr>
+      <td><%= food.name %></td>
+      <td><%= food.quantity %></td>
+      <td><%= food.price %></td>
+      <td><%= link_to 'Delete', food_path(food), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+    </tr>
+  <% end %>
+</table>
+
+<%= link_to 'Add Food', new_food_path %>

--- a/app/views/foods/new.html.erb
+++ b/app/views/foods/new.html.erb
@@ -1,0 +1,24 @@
+<h1>Add New Food Item</h1>
+
+<%= form_for @food do |f| %>
+  <div class="field">
+    <%= f.label :name %>
+    <%= f.text_field :name %>
+  </div>
+
+  <div class="field">
+    <%= f.label :quantity %>
+    <%= f.number_field :quantity %>
+  </div>
+
+  <div class="field">
+    <%= f.label :price %>
+    <%= f.number_field :price %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit 'Add Food' %>
+  </div>
+<% end %>
+
+<%= link_to 'Back to Food List', foods_path %>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -14,6 +14,7 @@
     <nav>
       <ul>
         <li><%= link_to "Home", root_path %></li>
+        <li><%= link_to "Food List", foods_path %></li>
         <li><%= link_to "Login", new_user_session_path %></li>
         <li><%= link_to "Register", new_user_registration_path %></li>
       </ul>

--- a/config/database.yml
+++ b/config/database.yml
@@ -24,10 +24,6 @@ default: &default
 development:
   <<: *default
   database: recipe_app_development
-  username: postgres
-
-  # The password associated with the postgres role (username).
-  password: "1234"
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -62,10 +58,6 @@ development:
 test:
   <<: *default
   database: recipe_app_test
-  username: postgres
-
-  # The password associated with the postgres role (username).
-  password: "1234"
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ Rails.application.routes.draw do
 
   root to: "home#index"
   resources :recipes 
-  
+  resources :foods
 end


### PR DESCRIPTION
## Recipe App: Add Food list page

In this milestone, I introduced the Food List feature, including full CRUD (Create, Read, Delete) functionality for managing food items within the RecipeApp. The primary components of this feature include:

- Food List Page:
   - The Food List page displays a tabular list of food items added by the logged-in user.
   - Each item in the list includes the food name, quantity, unit price, and an action to delete the food item.
- Add Food Form:
   - Users can add new food items through a dedicated form accessible from the "Add Food" button on the Food List page.
- Deletion of Food Items:
   - Users can delete food items directly from the Food List by clicking the delete action.
- Authorization:
   - Implemented authorization using the CanCanCan gem to ensure that users can only delete their own food items.
The changes made in this pull request enhance the user experience by allowing users to manage their food items easily.